### PR TITLE
Fix/stateful sessions duplicate reactive dict bug

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -1,7 +1,7 @@
 {
   "space:base": {
     "git":"https://github.com/meteor-space/base.git",
-    "branch": "fix/let-mixins-override-prototype-methods"
+    "branch": "develop"
   },
   "space:messaging": {
     "git":"https://github.com/meteor-space/messaging.git",

--- a/source/mixins/stateful.js
+++ b/source/mixins/stateful.js
@@ -1,5 +1,9 @@
 Space.flux.Stateful = {
 
+  statics: {
+    _session: null
+  },
+
   dependencies: {
     ReactiveVar: 'ReactiveVar',
     ReactiveDict: 'ReactiveDict',
@@ -14,7 +18,11 @@ Space.flux.Stateful = {
   onDependenciesReady: function() {
     this._reactiveVars = {};
     this._setupReactiveVars();
-    this._session = new this.ReactiveDict(this._session);
+    // Only create one static singleton of the reactive-dict for this class!
+    if (this.constructor._session === null) {
+      this.constructor._session = new this.ReactiveDict(this._session);
+    }
+    this._session = this.constructor._session;
     this._setDefaultSessionVars();
     this._computations = [];
     for (computation of this.computations()) {


### PR DESCRIPTION
Meteor does not allow to create `ReactiveDict` with same name multiple times. So this PR makes it a static singleton for each class that `Stateful` is mixed into.